### PR TITLE
replace types with structs

### DIFF
--- a/src/DimensionalityReduction.jl
+++ b/src/DimensionalityReduction.jl
@@ -11,7 +11,7 @@ export sample_data, VI
 
 ####################
 ## Types
-type DRModel
+struct DRModel
     D::Int
     M::Int
     sigma2_y::Float64

--- a/src/GaussianMixtureModel.jl
+++ b/src/GaussianMixtureModel.jl
@@ -12,7 +12,7 @@ export learn_GS, learn_CGS, learn_VI
 
 ####################
 ## Types
-type GW
+struct GW
     # Parameters of Gauss Wisahrt distribution
     beta::Float64
     m::Vector{Float64}
@@ -20,7 +20,7 @@ type GW
     W::Matrix{Float64}
 end
 
-type BGMM
+struct BGMM
     # Parameters of Bayesian Gaussian Mixture Model 
     D::Int
     K::Int
@@ -28,13 +28,13 @@ type BGMM
     cmp::Vector{GW}
 end
 
-type Gauss
+struct Gauss
     # Parameters of Gauss Distribution
     mu::Vector{Float64}
     Lambda::Matrix{Float64}
 end
 
-type GMM
+struct GMM
     # Parameters of Gauss Mixture Model
     D::Int
     K::Int

--- a/src/NMF.jl
+++ b/src/NMF.jl
@@ -10,7 +10,7 @@ export sample_data, VI
 
 ####################
 ## Types
-type NMFModel
+struct NMFModel
     a_t::Array{Float64, 2} # D x K
     b_t::Array{Float64, 2} # D x L
     a_v::Float64 # 1 dim

--- a/src/PoissonHMM.jl
+++ b/src/PoissonHMM.jl
@@ -11,14 +11,14 @@ export learn_VI
 
 ####################
 ## Types
-type Gam
+struct Gam
     # Parameters of Gamma distribution
     # 1dim
     a::Float64
     b::Float64
 end
 
-type BHMM
+struct BHMM
     # Parameters of Bayesian Bernoulli Mixture Model 
     K::Int
     alpha_phi::Vector{Float64}
@@ -26,13 +26,13 @@ type BHMM
     cmp::Vector{Gam}
 end
 
-type Poi
+struct Poi
     # Parameters of Poisson Distribution
     # 1 dim
     lambda::Float64
 end
 
-type HMM
+struct HMM
     # Parameters of Bernoulli Mixture Model
     K::Int
     phi::Vector{Float64}

--- a/src/PoissonMixtureModel.jl
+++ b/src/PoissonMixtureModel.jl
@@ -11,13 +11,13 @@ export learn_GS, learn_CGS, learn_VI
 
 ####################
 ## Types
-type Gam
+struct Gam
     # Parameters of Gamma distribution
     a::Vector{Float64}
     b::Float64
 end
 
-type BPMM
+struct BPMM
     # Parameters of Bayesian Poisson Mixture Model 
     D::Int
     K::Int
@@ -25,12 +25,12 @@ type BPMM
     cmp::Vector{Gam}
 end
 
-type Poi
+struct Poi
     # Parameters of Poisson Distribution
     lambda::Vector{Float64}
 end
 
-type PMM
+struct PMM
     # Parameters of Poisson Mixture Model
     D::Int
     K::Int


### PR DESCRIPTION
The `type` keyword is deprecated in the development branch of Julia and will be removed completely in Julia 1.0. If you recommend readers to use Julia 0.6, using `struct` (or `mutable struct`) is advisable. If you do that intentionally, I'm sorry for making noise.